### PR TITLE
Fix: Use absolute path for exec in self_update_script

### DIFF
--- a/ACrebuild.sh
+++ b/ACrebuild.sh
@@ -906,7 +906,8 @@ self_update_script() {
     OLDPWD_PREV="${OLDPWD:-$HOME}"
     cd "$OLDPWD_PREV" &>/dev/null
 
-    exec "$0" "$@" # Replace current script process with the new version
+    local script_actual_name=$(basename "${BASH_SOURCE[0]}")
+    exec "$SCRIPT_DIR_PATH/$script_actual_name" "$@" # Replace current script process with the new version
     # If exec fails for some reason (it shouldn't normally), exit to prevent unexpected behavior.
     print_message $RED "Error: Failed to restart the script with exec. Please restart it manually." true
     exit 1


### PR DESCRIPTION
I changed the self-update mechanism to use an absolute path when re-executing the script (`exec "$SCRIPT_DIR_PATH/$(basename "${BASH_SOURCE[0]}")" "$@"`).

Previously, it used `exec "$0" "$@"`, which could fail with a "No such file or directory" error if `$0` was a relative path and the script's current working directory had changed, or if the script was called via a symlink in certain ways.

This change ensures that the script can reliably restart itself after an update by using the definitively known `SCRIPT_DIR_PATH` (determined at script startup) and the actual script's basename derived from `${BASH_SOURCE[0]}`.