### PR TITLE
UX: Add 'Go Back' option to restore backup menu

### DIFF
--- a/ACrebuild.sh
+++ b/ACrebuild.sh
@@ -1002,6 +1002,7 @@ list_backups() {
         BACKUP_FILES[i]="$backup_file" # Store full path
         i=$((i+1))
     done
+    print_message $CYAN "  [0] Go Back to Backup/Restore Menu" false
     echo ""
     return 0
 }
@@ -1148,6 +1149,12 @@ restore_backup() {
     print_message $YELLOW "Enter the number of the backup to restore:" true
     read -r backup_choice
     echo ""
+
+    # Check if user wants to go back
+    if [[ "$backup_choice" == "0" ]]; then
+        print_message $GREEN "Returning to Backup/Restore menu..." false
+        return 0 # Or just return, as it goes back to the menu loop
+    fi
 
     # Validate input
     if ! [[ "$backup_choice" =~ ^[0-9]+$ ]] || [ "$backup_choice" -lt 1 ] || [ "$backup_choice" -gt ${#BACKUP_FILES[@]} ]; then


### PR DESCRIPTION
This improves your experience in the backup restoration flow:

1.  The `list_backups` function now displays an explicit "[0] Go Back to Backup/Restore Menu" option alongside the list of available backups.
2.  The `restore_backup` function now handles the input "0" at the backup selection prompt, allowing you to return gracefully to the main Backup/Restore menu without needing to Ctrl+C or make an invalid selection.